### PR TITLE
Add support for koa newer version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # koa-json-mask
 
-  Middleware allowing the client to mask / filter the response to only what they need,
-  reducing the amount of traffic over the wire using the `?fields=foo,bar,baz`
-  querystring parameter.
+Middleware allowing the client to mask / filter the response to only what they need,
+reducing the amount of traffic over the wire using the `?fields=foo,bar,baz`
+querystring parameter.
 
-  If you've used the Google APIs, provided a `?fields=` query-string to get a
-  [Partial Response](https://developers.google.com/+/api/#partial-responses),
-  and wanted to do the same for your own server, you can do so with this
-  middleware.
+If you've used the Google APIs, provided a `?fields=` query-string to get a
+[Partial Response](https://developers.google.com/+/api/#partial-responses),
+and wanted to do the same for your own server, you can do so with this
+middleware.
 
-  The difference between `koa-json-filter` and `koa-json-mask` is that this middleware
-  supports filtering parts deep within objects. If you only need to be able to
-  filter top-level params of objects in the response use `filter`, and if you need
-  more power user `mask`.
+The difference between `koa-json-filter` and `koa-json-mask` is that this middleware
+supports filtering parts deep within objects. If you only need to be able to
+filter top-level params of objects in the response use `filter`, and if you need
+more power user `mask`.
 
-  *Underneath, this middleware uses [json-mask](https://github.com/nemtsov/json-mask).
-  Use it directly without this middleware if you need more flexibility.*
-
+_Underneath, this middleware uses [json-mask](https://github.com/nemtsov/json-mask).
+Use it directly without this middleware if you need more flexibility._
 
 ## Installation
 
@@ -24,27 +23,32 @@
 $ npm install koa-json-mask
 ```
 
+In order to use this plugin with the previous version of Koa using generator functions, please use version `0.3.2`
+
+```
+$ npm install koa-json-mask@0.3.2
+```
+
 ## Options
 
- - `name` querystring param name defaulting to "fields"
-
+* `name` querystring param name defaulting to "fields"
 
 ## Example
 
 ### Object responses
 
-  Script:
+Script:
 
 ```js
-var mask = require('koa-json-mask');
-var koa = require('koa');
+const Koa = require('koa');
+const mask = require('koa-json-mask');
 
-var app = koa();
+const app = new Koa();
 
 app.use(mask());
 
-app.use(function *() {
-  this.body = {
+app.use(async ctx => {
+  ctx.body = {
     name: 'tobi',
     packages: 5,
     friends: ['abby', 'loki', 'jane'],
@@ -52,14 +56,14 @@ app.use(function *() {
       id: '342',
       name: 'London'
     }
-  }
+  };
 });
 
 app.listen(3000);
 console.log('app listening on port 3000');
 ```
 
-  Response:
+Response:
 
 ```
 $ GET /?fields=name,location/name
@@ -73,18 +77,18 @@ $ GET /?fields=name,location/name
 
 ### Array responses
 
- Script:
+Script:
 
 ```js
-var mask = require('koa-json-mask');
-var koa = require('koa');
+const Koa = require('koa');
+const mask = require('koa-json-mask');
 
-var app = koa();
+const app = new Koa();
 
 app.use(mask());
 
-app.use(function *() {
-  this.body = [
+app.use(async ctx => {
+  ctx.body = [
     {
       name: 'tobi',
       packages: 5,
@@ -110,7 +114,7 @@ app.listen(3000);
 console.log('app listening on port 3000');
 ```
 
-  Response:
+Response:
 
 ```
 $ GET /?fields=name,location/name
@@ -134,18 +138,16 @@ $ GET /?fields=name,location/name
 
 The syntax is loosely based on XPath:
 
-- ` a,b,c` comma-separated list will select multiple fields
-- ` a/b/c` path will select a field from its parent
-- `a(b,c)` sub-selection will select many fields from a parent
-- ` a/*/c` the star `*` wildcard will select all items in a field
-
+* `a,b,c` comma-separated list will select multiple fields
+* `a/b/c` path will select a field from its parent
+* `a(b,c)` sub-selection will select many fields from a parent
+* `a/*/c` the star `*` wildcard will select all items in a field
 
 ## More examples
 
 For more examples, take a look at the
 [examples section of the json-mask README](https://github.com/nemtsov/json-mask/#examples).
 
-
 # License
 
-  MIT
+MIT

--- a/examples/array.js
+++ b/examples/array.js
@@ -1,17 +1,16 @@
-
 /**
  * Module dependencies.
  */
 
-var mask = require('..');
-var koa = require('koa');
+const mask = require('..');
+const Koa = require('koa');
 
-var app = koa();
+const app = new Koa();
 
 app.use(mask());
 
-app.use(function *(){
-  this.body = [
+app.use(async ctx => {
+  ctx.body = [
     {
       name: 'tobi',
       packages: 5,

--- a/examples/object.js
+++ b/examples/object.js
@@ -1,17 +1,16 @@
-
 /**
  * Module dependencies.
  */
 
-var mask = require('..');
-var koa = require('koa');
+const mask = require('..');
+const Koa = require('koa');
 
-var app = koa();
+const app = new Koa();
 
 app.use(mask());
 
-app.use(function *(){
-  this.body = {
+app.use(async ctx => {
+  ctx.body = {
     name: 'tobi',
     packages: 5,
     friends: ['abby', 'loki', 'jane'],
@@ -19,7 +18,7 @@ app.use(function *(){
       id: '342',
       name: 'London'
     }
-  }
+  };
 });
 
 app.listen(3000);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-var jsonMask = require('json-mask');
-var compile = jsonMask.compile;
-var filter = jsonMask.filter;
+const jsonMask = require('json-mask');
+const compile = jsonMask.compile;
+const filter = jsonMask.filter;
 
 /**
  * Mask parts of the response.
@@ -8,26 +8,26 @@ var filter = jsonMask.filter;
  *  - `name` querystring param name [fields]
  *
  * @param {Object} opts
- * @return {GeneratorFunction}
+ * @return {Promise}
  * @api public
  */
 
-module.exports = function (opts) {
+module.exports = opts => {
   opts = opts || {};
-  var name = opts.name || 'fields';
+  const name = opts.name || 'fields';
 
-  return function *mask(next) {
-    yield *next;
+  return async function mask(ctx, next) {
+    await next();
 
-    var body = this.body;
+    const body = ctx.body;
 
     // non-json
     if (!body || 'object' != typeof body) return;
 
     // check for fields
-    var fields = this.query[name] || this.fields;
+    const fields = ctx.query[name] || ctx.fields;
     if (!fields) return;
 
-    this.body = filter(this.body, compile(fields));
+    ctx.body = filter(ctx.body, compile(fields));
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,28 +1,44 @@
 {
   "name": "koa-json-mask",
-  "version": "0.3.2",
-  "repository": "nemtsov/koa-json-mask",
-  "description": "middleware allowing the client to filter the response to only what they need",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nemtsov/koa-json-mask.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nemtsov/koa-json-mask/issues"
+  },
+  "homepage": "https://github.com/nemtsov/koa-json-mask#readme",
+  "description":
+    "Middleware allowing the client to filter the response to only what they need",
+  "directories": {
+    "example": "examples",
+    "test": "test"
+  },
   "keywords": [
     "koa",
     "middleware",
     "performance",
     "mask",
+    "field",
     "filter",
     "partial",
     "partial response"
   ],
   "dependencies": {
-    "json-mask": "~0.3.2"
+    "json-mask": "^0.3.8"
   },
   "scripts": {
-    "test": "mocha --harmony --require should --bail"
+    "test": "mocha"
   },
   "devDependencies": {
-    "mocha": "*",
-    "should": "*",
-    "koa": "~0.2.1",
-    "supertest": "~0.8.2"
+    "koa": "^2.4.1",
+    "mocha": "^5.0.0",
+    "supertest": "^3.0.0"
   },
+  "engines": {
+    "node": ">=7.6.0"
+  },
+  "files": ["index.js"],
   "license": "MIT"
 }


### PR DESCRIPTION
Just found your package that is really awesome. As I'm often using koa for my project, I updated the code base to support newer version of Koa with async/await. It's a breaking change update.

It includes :

* replaced usage of generator functions by async/await
* updated examples
* updated readme
* updated dependencies
* updated package information and bumped package version from `0.3.2` to `1.0.0`

Let me know if I missed anything.